### PR TITLE
fix: resolve backfill job queue exhaustion bug

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5185,7 +5185,7 @@ dependencies = [
 
 [[package]]
 name = "waypoint"
-version = "2025.6.0"
+version = "2025.6.1"
 dependencies = [
  "alloy-primitives",
  "alloy-provider",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "waypoint"
-version = "2025.6.0"
+version = "2025.6.1"
 edition = "2024"
 default-run = "waypoint"
 rust-version = "1.85.0"


### PR DESCRIPTION
## Summary

This PR fixes a critical bug in the backfill worker where jobs would stop being processed after the initial batch, causing the backfill to appear stuck even though jobs were completing successfully.

## Problem

The backfill worker was experiencing queue exhaustion where:
- Jobs would process successfully but no new jobs would be queued
- When large jobs were split, the remaining FIDs were not being properly requeued
- The queue length calculation only checked the normal priority queue, missing high and low priority jobs
- Lack of visibility into queue state made debugging difficult

## Solution

### 1. Fixed Job Splitting Logic
- Moved job requeueing from a spawned task to the main execution flow
- Properly create new `BackfillJob` objects instead of cloning
- Ensure split jobs are immediately added back to the queue

### 2. Enhanced Queue Monitoring
- Added detailed logging throughout the queue operations
- Log queue state across all priority levels (high, normal, low)
- Track FID ranges being processed for better visibility

### 3. Fixed Queue Length Calculation
- `get_queue_length()` now properly sums all priority queues
- Provides accurate total job count for monitoring

### 4. Added Auto-Queueing Mechanism
- Track highest processed FID during backfill
- Optionally auto-queue more FIDs when all queues are empty
- Prevents backfill from stopping prematurely

### 5. Code Cleanup
- Removed unnecessary comments and variables
- Simplified control flow
- Removed unused database connection limiter

## Testing

The changes include improved logging that will help verify:
- Jobs are being split and requeued correctly
- Queue state is accurately reported
- Backfill continues processing until completion

## Breaking Changes

None - all changes are internal improvements to the backfill worker.