### PR TITLE
fix: handle Redis XPENDING response variations and prevent backfill job loss

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,9 @@ All notable changes to Waypoint will be documented in this file.
 ### Bug Fixes
 
 - Resolve backfill job queue exhaustion bug (#37)
-- Increase Redis pool sizes to prevent backfill queue exhaustion
+- Increase Redis pool sizes to prevent backfill queue exhaustion (#38)
+- Handle Redis XPENDING response type variations
+- Prevent backfill job loss by removing Redis key expiration
 
 ### Features
 
@@ -15,7 +17,7 @@ All notable changes to Waypoint will be documented in this file.
 
 ### Miscellaneous Tasks
 
-- Version
+- Bump version to 2025.6.3
 
 ## [0.6.3] - 2025-06-09
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5185,7 +5185,7 @@ dependencies = [
 
 [[package]]
 name = "waypoint"
-version = "2025.6.2"
+version = "2025.6.3"
 dependencies = [
  "alloy-primitives",
  "alloy-provider",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "waypoint"
-version = "2025.6.2"
+version = "2025.6.3"
 edition = "2024"
 default-run = "waypoint"
 rust-version = "1.85.0"

--- a/src/commands/backfill/fid/queue.rs
+++ b/src/commands/backfill/fid/queue.rs
@@ -121,6 +121,7 @@ pub async fn execute(config: &Config, args: &ArgMatches) -> Result<()> {
                     attempts: 0,
                     created_at: chrono::Utc::now(),
                     id: String::new(),
+                    started_at: None,
                 })
                 .await?;
 
@@ -157,6 +158,7 @@ pub async fn execute(config: &Config, args: &ArgMatches) -> Result<()> {
                 attempts: 0,
                 created_at: chrono::Utc::now(),
                 id: String::new(),
+                started_at: None,
             })
             .await?;
         info!("Queued specific FIDs: {:?}", fid_list);
@@ -181,6 +183,7 @@ pub async fn execute(config: &Config, args: &ArgMatches) -> Result<()> {
                     attempts: 0,
                     created_at: chrono::Utc::now(),
                     id: String::new(),
+                    started_at: None,
                 })
                 .await?;
 

--- a/src/redis/client.rs
+++ b/src/redis/client.rs
@@ -428,16 +428,14 @@ impl Redis {
                 .await;
 
         match items_with_idle {
-            Ok(items) => {
-                Ok(items
-                    .into_iter()
-                    .map(|(id, _, idle_time, count)| PendingItem {
-                        id,
-                        idle_time: idle_time.parse().unwrap_or(0),
-                        delivery_count: count.parse().unwrap_or(0),
-                    })
-                    .collect())
-            },
+            Ok(items) => Ok(items
+                .into_iter()
+                .map(|(id, _, idle_time, count)| PendingItem {
+                    id,
+                    idle_time: idle_time.parse().unwrap_or(0),
+                    delivery_count: count.parse().unwrap_or(0),
+                })
+                .collect()),
             Err(_) => {
                 // Fallback to standard XPENDING without IDLE (older Redis versions)
                 // We'll have to filter by idle time manually

--- a/src/redis/stream.rs
+++ b/src/redis/stream.rs
@@ -231,10 +231,9 @@ impl RedisStream {
                                     // Use a larger batch size for all groups for better performance
                                     let batch_size = 100;
 
-                                    let pending_result: Result<
-                                        PendingResult,
-                                        bb8_redis::redis::RedisError,
-                                    > = bb8_redis::redis::cmd("XPENDING")
+                                    // Get raw response first to handle different formats
+                                    let pending_raw: Result<bb8_redis::redis::Value, bb8_redis::redis::RedisError> =
+                                        bb8_redis::redis::cmd("XPENDING")
                                             .arg(sk)
                                             .arg(gn)
                                             .arg("-")  // start ID
@@ -243,6 +242,39 @@ impl RedisStream {
                                             .arg(idle_consumer)
                                             .query_async(&mut *conn)
                                             .await;
+                                            
+                                    let pending_result: Result<PendingResult, bb8_redis::redis::RedisError> =
+                                        match pending_raw {
+                                            Ok(bb8_redis::redis::Value::Array(arr)) => {
+                                                let mut items = Vec::new();
+                                                for val in arr {
+                                                    if let bb8_redis::redis::Value::Array(entry) = val {
+                                                        if entry.len() >= 4 {
+                                                            let id = match &entry[0] {
+                                                                bb8_redis::redis::Value::BulkString(s) => String::from_utf8_lossy(s).to_string(),
+                                                                _ => continue,
+                                                            };
+                                                            let consumer = match &entry[1] {
+                                                                bb8_redis::redis::Value::BulkString(s) => String::from_utf8_lossy(s).to_string(),
+                                                                _ => continue,
+                                                            };
+                                                            let idle_time = match &entry[2] {
+                                                                bb8_redis::redis::Value::Int(i) => *i as u64,
+                                                                bb8_redis::redis::Value::BulkString(s) => {
+                                                                    String::from_utf8_lossy(s).parse::<u64>().unwrap_or(0)
+                                                                },
+                                                                _ => 0,
+                                                            };
+                                                            items.push((id, consumer, idle_time, Vec::new()));
+                                                        }
+                                                    }
+                                                }
+                                                Ok(items)
+                                            },
+                                            Ok(bb8_redis::redis::Value::Int(0)) | Ok(bb8_redis::redis::Value::Nil) => Ok(Vec::new()),
+                                            Ok(_) => Ok(Vec::new()),
+                                            Err(e) => Err(e),
+                                        };
 
                                     match pending_result {
                                         Ok(pending_msgs) if !pending_msgs.is_empty() => {
@@ -276,18 +308,49 @@ impl RedisStream {
                                                 // Continue claiming in a loop until no more messages
                                                 let mut claimed_all = false;
                                                 while !claimed_all {
-                                                    let more_pending: Result<
-                                                        PendingResult,
-                                                        bb8_redis::redis::RedisError,
-                                                    > = bb8_redis::redis::cmd("XPENDING")
-                                                        .arg(sk)
-                                                        .arg(gn)
-                                                        .arg("-")
-                                                        .arg("+")
-                                                        .arg(batch_size)
-                                                        .arg(idle_consumer)
-                                                        .query_async(&mut *conn)
-                                                        .await;
+                                                    let more_raw: Result<bb8_redis::redis::Value, bb8_redis::redis::RedisError> =
+                                                        bb8_redis::redis::cmd("XPENDING")
+                                                            .arg(sk)
+                                                            .arg(gn)
+                                                            .arg("-")
+                                                            .arg("+")
+                                                            .arg(batch_size)
+                                                            .arg(idle_consumer)
+                                                            .query_async(&mut *conn)
+                                                            .await;
+                                                            
+                                                    let more_pending: Result<PendingResult, bb8_redis::redis::RedisError> =
+                                                        match more_raw {
+                                                            Ok(bb8_redis::redis::Value::Array(arr)) => {
+                                                                let mut items = Vec::new();
+                                                                for val in arr {
+                                                                    if let bb8_redis::redis::Value::Array(entry) = val {
+                                                                        if entry.len() >= 4 {
+                                                                            let id = match &entry[0] {
+                                                                                bb8_redis::redis::Value::BulkString(s) => String::from_utf8_lossy(s).to_string(),
+                                                                                _ => continue,
+                                                                            };
+                                                                            let consumer = match &entry[1] {
+                                                                                bb8_redis::redis::Value::BulkString(s) => String::from_utf8_lossy(s).to_string(),
+                                                                                _ => continue,
+                                                                            };
+                                                                            let idle_time = match &entry[2] {
+                                                                                bb8_redis::redis::Value::Int(i) => *i as u64,
+                                                                                bb8_redis::redis::Value::BulkString(s) => {
+                                                                                    String::from_utf8_lossy(s).parse::<u64>().unwrap_or(0)
+                                                                                },
+                                                                                _ => 0,
+                                                                            };
+                                                                            items.push((id, consumer, idle_time, Vec::new()));
+                                                                        }
+                                                                    }
+                                                                }
+                                                                Ok(items)
+                                                            },
+                                                            Ok(bb8_redis::redis::Value::Int(0)) | Ok(bb8_redis::redis::Value::Nil) => Ok(Vec::new()),
+                                                            Ok(_) => Ok(Vec::new()),
+                                                            Err(e) => Err(e),
+                                                        };
 
                                                     match more_pending {
                                                         Ok(more_msgs) if !more_msgs.is_empty() => {
@@ -352,10 +415,8 @@ impl RedisStream {
                             for consumer_id in &extremely_idle_consumers {
                                 // Check if consumer has pending messages after claiming
                                 type PendingResult = Vec<(String, String, u64, Vec<(String, u64)>)>;
-                                let pending_check: Result<
-                                    PendingResult,
-                                    bb8_redis::redis::RedisError,
-                                > = bb8_redis::redis::cmd("XPENDING")
+                                let pending_check_raw: Result<bb8_redis::redis::Value, bb8_redis::redis::RedisError> =
+                                    bb8_redis::redis::cmd("XPENDING")
                                         .arg(&stream_key)
                                         .arg(&group_name)
                                         .arg("-")
@@ -364,6 +425,39 @@ impl RedisStream {
                                         .arg(consumer_id)
                                         .query_async(&mut *conn)
                                         .await;
+                                        
+                                let pending_check: Result<PendingResult, bb8_redis::redis::RedisError> =
+                                    match pending_check_raw {
+                                        Ok(bb8_redis::redis::Value::Array(arr)) => {
+                                            let mut items = Vec::new();
+                                            for val in arr {
+                                                if let bb8_redis::redis::Value::Array(entry) = val {
+                                                    if entry.len() >= 4 {
+                                                        let id = match &entry[0] {
+                                                            bb8_redis::redis::Value::BulkString(s) => String::from_utf8_lossy(s).to_string(),
+                                                            _ => continue,
+                                                        };
+                                                        let consumer = match &entry[1] {
+                                                            bb8_redis::redis::Value::BulkString(s) => String::from_utf8_lossy(s).to_string(),
+                                                            _ => continue,
+                                                        };
+                                                        let idle_time = match &entry[2] {
+                                                            bb8_redis::redis::Value::Int(i) => *i as u64,
+                                                            bb8_redis::redis::Value::BulkString(s) => {
+                                                                String::from_utf8_lossy(s).parse::<u64>().unwrap_or(0)
+                                                            },
+                                                            _ => 0,
+                                                        };
+                                                        items.push((id, consumer, idle_time, Vec::new()));
+                                                    }
+                                                }
+                                            }
+                                            Ok(items)
+                                        },
+                                        Ok(bb8_redis::redis::Value::Int(0)) | Ok(bb8_redis::redis::Value::Nil) => Ok(Vec::new()),
+                                        Ok(_) => Ok(Vec::new()),
+                                        Err(e) => Err(e),
+                                    };
 
                                 let has_pending = match pending_check {
                                     Ok(msgs) => !msgs.is_empty(),

--- a/src/redis/stream.rs
+++ b/src/redis/stream.rs
@@ -232,8 +232,10 @@ impl RedisStream {
                                     let batch_size = 100;
 
                                     // Get raw response first to handle different formats
-                                    let pending_raw: Result<bb8_redis::redis::Value, bb8_redis::redis::RedisError> =
-                                        bb8_redis::redis::cmd("XPENDING")
+                                    let pending_raw: Result<
+                                        bb8_redis::redis::Value,
+                                        bb8_redis::redis::RedisError,
+                                    > = bb8_redis::redis::cmd("XPENDING")
                                             .arg(sk)
                                             .arg(gn)
                                             .arg("-")  // start ID
@@ -242,39 +244,57 @@ impl RedisStream {
                                             .arg(idle_consumer)
                                             .query_async(&mut *conn)
                                             .await;
-                                            
-                                    let pending_result: Result<PendingResult, bb8_redis::redis::RedisError> =
-                                        match pending_raw {
-                                            Ok(bb8_redis::redis::Value::Array(arr)) => {
-                                                let mut items = Vec::new();
-                                                for val in arr {
-                                                    if let bb8_redis::redis::Value::Array(entry) = val {
-                                                        if entry.len() >= 4 {
-                                                            let id = match &entry[0] {
-                                                                bb8_redis::redis::Value::BulkString(s) => String::from_utf8_lossy(s).to_string(),
-                                                                _ => continue,
-                                                            };
-                                                            let consumer = match &entry[1] {
-                                                                bb8_redis::redis::Value::BulkString(s) => String::from_utf8_lossy(s).to_string(),
-                                                                _ => continue,
-                                                            };
-                                                            let idle_time = match &entry[2] {
-                                                                bb8_redis::redis::Value::Int(i) => *i as u64,
-                                                                bb8_redis::redis::Value::BulkString(s) => {
-                                                                    String::from_utf8_lossy(s).parse::<u64>().unwrap_or(0)
-                                                                },
-                                                                _ => 0,
-                                                            };
-                                                            items.push((id, consumer, idle_time, Vec::new()));
-                                                        }
+
+                                    let pending_result: Result<
+                                        PendingResult,
+                                        bb8_redis::redis::RedisError,
+                                    > = match pending_raw {
+                                        Ok(bb8_redis::redis::Value::Array(arr)) => {
+                                            let mut items = Vec::new();
+                                            for val in arr {
+                                                if let bb8_redis::redis::Value::Array(entry) = val {
+                                                    if entry.len() >= 4 {
+                                                        let id = match &entry[0] {
+                                                            bb8_redis::redis::Value::BulkString(
+                                                                s,
+                                                            ) => String::from_utf8_lossy(s)
+                                                                .to_string(),
+                                                            _ => continue,
+                                                        };
+                                                        let consumer = match &entry[1] {
+                                                            bb8_redis::redis::Value::BulkString(
+                                                                s,
+                                                            ) => String::from_utf8_lossy(s)
+                                                                .to_string(),
+                                                            _ => continue,
+                                                        };
+                                                        let idle_time = match &entry[2] {
+                                                            bb8_redis::redis::Value::Int(i) => {
+                                                                *i as u64
+                                                            },
+                                                            bb8_redis::redis::Value::BulkString(
+                                                                s,
+                                                            ) => String::from_utf8_lossy(s)
+                                                                .parse::<u64>()
+                                                                .unwrap_or(0),
+                                                            _ => 0,
+                                                        };
+                                                        items.push((
+                                                            id,
+                                                            consumer,
+                                                            idle_time,
+                                                            Vec::new(),
+                                                        ));
                                                     }
                                                 }
-                                                Ok(items)
-                                            },
-                                            Ok(bb8_redis::redis::Value::Int(0)) | Ok(bb8_redis::redis::Value::Nil) => Ok(Vec::new()),
-                                            Ok(_) => Ok(Vec::new()),
-                                            Err(e) => Err(e),
-                                        };
+                                            }
+                                            Ok(items)
+                                        },
+                                        Ok(bb8_redis::redis::Value::Int(0))
+                                        | Ok(bb8_redis::redis::Value::Nil) => Ok(Vec::new()),
+                                        Ok(_) => Ok(Vec::new()),
+                                        Err(e) => Err(e),
+                                    };
 
                                     match pending_result {
                                         Ok(pending_msgs) if !pending_msgs.is_empty() => {
@@ -308,23 +328,27 @@ impl RedisStream {
                                                 // Continue claiming in a loop until no more messages
                                                 let mut claimed_all = false;
                                                 while !claimed_all {
-                                                    let more_raw: Result<bb8_redis::redis::Value, bb8_redis::redis::RedisError> =
-                                                        bb8_redis::redis::cmd("XPENDING")
-                                                            .arg(sk)
-                                                            .arg(gn)
-                                                            .arg("-")
-                                                            .arg("+")
-                                                            .arg(batch_size)
-                                                            .arg(idle_consumer)
-                                                            .query_async(&mut *conn)
-                                                            .await;
-                                                            
-                                                    let more_pending: Result<PendingResult, bb8_redis::redis::RedisError> =
-                                                        match more_raw {
-                                                            Ok(bb8_redis::redis::Value::Array(arr)) => {
-                                                                let mut items = Vec::new();
-                                                                for val in arr {
-                                                                    if let bb8_redis::redis::Value::Array(entry) = val {
+                                                    let more_raw: Result<
+                                                        bb8_redis::redis::Value,
+                                                        bb8_redis::redis::RedisError,
+                                                    > = bb8_redis::redis::cmd("XPENDING")
+                                                        .arg(sk)
+                                                        .arg(gn)
+                                                        .arg("-")
+                                                        .arg("+")
+                                                        .arg(batch_size)
+                                                        .arg(idle_consumer)
+                                                        .query_async(&mut *conn)
+                                                        .await;
+
+                                                    let more_pending: Result<
+                                                        PendingResult,
+                                                        bb8_redis::redis::RedisError,
+                                                    > = match more_raw {
+                                                        Ok(bb8_redis::redis::Value::Array(arr)) => {
+                                                            let mut items = Vec::new();
+                                                            for val in arr {
+                                                                if let bb8_redis::redis::Value::Array(entry) = val {
                                                                         if entry.len() >= 4 {
                                                                             let id = match &entry[0] {
                                                                                 bb8_redis::redis::Value::BulkString(s) => String::from_utf8_lossy(s).to_string(),
@@ -344,13 +368,16 @@ impl RedisStream {
                                                                             items.push((id, consumer, idle_time, Vec::new()));
                                                                         }
                                                                     }
-                                                                }
-                                                                Ok(items)
-                                                            },
-                                                            Ok(bb8_redis::redis::Value::Int(0)) | Ok(bb8_redis::redis::Value::Nil) => Ok(Vec::new()),
-                                                            Ok(_) => Ok(Vec::new()),
-                                                            Err(e) => Err(e),
-                                                        };
+                                                            }
+                                                            Ok(items)
+                                                        },
+                                                        Ok(bb8_redis::redis::Value::Int(0))
+                                                        | Ok(bb8_redis::redis::Value::Nil) => {
+                                                            Ok(Vec::new())
+                                                        },
+                                                        Ok(_) => Ok(Vec::new()),
+                                                        Err(e) => Err(e),
+                                                    };
 
                                                     match more_pending {
                                                         Ok(more_msgs) if !more_msgs.is_empty() => {
@@ -415,8 +442,10 @@ impl RedisStream {
                             for consumer_id in &extremely_idle_consumers {
                                 // Check if consumer has pending messages after claiming
                                 type PendingResult = Vec<(String, String, u64, Vec<(String, u64)>)>;
-                                let pending_check_raw: Result<bb8_redis::redis::Value, bb8_redis::redis::RedisError> =
-                                    bb8_redis::redis::cmd("XPENDING")
+                                let pending_check_raw: Result<
+                                    bb8_redis::redis::Value,
+                                    bb8_redis::redis::RedisError,
+                                > = bb8_redis::redis::cmd("XPENDING")
                                         .arg(&stream_key)
                                         .arg(&group_name)
                                         .arg("-")
@@ -425,39 +454,55 @@ impl RedisStream {
                                         .arg(consumer_id)
                                         .query_async(&mut *conn)
                                         .await;
-                                        
-                                let pending_check: Result<PendingResult, bb8_redis::redis::RedisError> =
-                                    match pending_check_raw {
-                                        Ok(bb8_redis::redis::Value::Array(arr)) => {
-                                            let mut items = Vec::new();
-                                            for val in arr {
-                                                if let bb8_redis::redis::Value::Array(entry) = val {
-                                                    if entry.len() >= 4 {
-                                                        let id = match &entry[0] {
-                                                            bb8_redis::redis::Value::BulkString(s) => String::from_utf8_lossy(s).to_string(),
-                                                            _ => continue,
-                                                        };
-                                                        let consumer = match &entry[1] {
-                                                            bb8_redis::redis::Value::BulkString(s) => String::from_utf8_lossy(s).to_string(),
-                                                            _ => continue,
-                                                        };
-                                                        let idle_time = match &entry[2] {
-                                                            bb8_redis::redis::Value::Int(i) => *i as u64,
-                                                            bb8_redis::redis::Value::BulkString(s) => {
-                                                                String::from_utf8_lossy(s).parse::<u64>().unwrap_or(0)
-                                                            },
-                                                            _ => 0,
-                                                        };
-                                                        items.push((id, consumer, idle_time, Vec::new()));
-                                                    }
+
+                                let pending_check: Result<
+                                    PendingResult,
+                                    bb8_redis::redis::RedisError,
+                                > = match pending_check_raw {
+                                    Ok(bb8_redis::redis::Value::Array(arr)) => {
+                                        let mut items = Vec::new();
+                                        for val in arr {
+                                            if let bb8_redis::redis::Value::Array(entry) = val {
+                                                if entry.len() >= 4 {
+                                                    let id = match &entry[0] {
+                                                        bb8_redis::redis::Value::BulkString(s) => {
+                                                            String::from_utf8_lossy(s).to_string()
+                                                        },
+                                                        _ => continue,
+                                                    };
+                                                    let consumer = match &entry[1] {
+                                                        bb8_redis::redis::Value::BulkString(s) => {
+                                                            String::from_utf8_lossy(s).to_string()
+                                                        },
+                                                        _ => continue,
+                                                    };
+                                                    let idle_time = match &entry[2] {
+                                                        bb8_redis::redis::Value::Int(i) => {
+                                                            *i as u64
+                                                        },
+                                                        bb8_redis::redis::Value::BulkString(s) => {
+                                                            String::from_utf8_lossy(s)
+                                                                .parse::<u64>()
+                                                                .unwrap_or(0)
+                                                        },
+                                                        _ => 0,
+                                                    };
+                                                    items.push((
+                                                        id,
+                                                        consumer,
+                                                        idle_time,
+                                                        Vec::new(),
+                                                    ));
                                                 }
                                             }
-                                            Ok(items)
-                                        },
-                                        Ok(bb8_redis::redis::Value::Int(0)) | Ok(bb8_redis::redis::Value::Nil) => Ok(Vec::new()),
-                                        Ok(_) => Ok(Vec::new()),
-                                        Err(e) => Err(e),
-                                    };
+                                        }
+                                        Ok(items)
+                                    },
+                                    Ok(bb8_redis::redis::Value::Int(0))
+                                    | Ok(bb8_redis::redis::Value::Nil) => Ok(Vec::new()),
+                                    Ok(_) => Ok(Vec::new()),
+                                    Err(e) => Err(e),
+                                };
 
                                 let has_pending = match pending_check {
                                     Ok(msgs) => !msgs.is_empty(),

--- a/src/services/streaming.rs
+++ b/src/services/streaming.rs
@@ -452,10 +452,9 @@ impl Consumer {
                                 // to avoid the infinitely sized future issue
                                 let mut continue_claims = true;
                                 while continue_claims {
-                                    let more_pending: std::result::Result<
-                                        PendingResult,
-                                        crate::redis::error::Error,
-                                    > = bb8_redis::redis::cmd("XPENDING")
+                                    // Get raw response for continuation
+                                    let more_raw: std::result::Result<bb8_redis::redis::Value, bb8_redis::redis::RedisError> =
+                                        bb8_redis::redis::cmd("XPENDING")
                                             .arg(stream_key)
                                             .arg(group_name)
                                             .arg("-")  // start ID
@@ -463,8 +462,40 @@ impl Consumer {
                                             .arg(BATCH_SIZE)
                                             .arg(consumer_name)
                                             .query_async(&mut *conn)
-                                            .await
-                                            .map_err(Error::RedisError);
+                                            .await;
+                                            
+                                    let more_pending: std::result::Result<Vec<PendingItem>, crate::redis::error::Error> =
+                                        match more_raw {
+                                            Ok(bb8_redis::redis::Value::Array(arr)) => {
+                                                let mut items = Vec::new();
+                                                for val in arr {
+                                                    if let bb8_redis::redis::Value::Array(entry) = val {
+                                                        if entry.len() >= 4 {
+                                                            let id = match &entry[0] {
+                                                                bb8_redis::redis::Value::BulkString(s) => String::from_utf8_lossy(s).to_string(),
+                                                                _ => continue,
+                                                            };
+                                                            let consumer = match &entry[1] {
+                                                                bb8_redis::redis::Value::BulkString(s) => String::from_utf8_lossy(s).to_string(),
+                                                                _ => continue,
+                                                            };
+                                                            let idle_time = match &entry[2] {
+                                                                bb8_redis::redis::Value::Int(i) => *i as u64,
+                                                                bb8_redis::redis::Value::BulkString(s) => {
+                                                                    String::from_utf8_lossy(s).parse::<u64>().unwrap_or(0)
+                                                                },
+                                                                _ => 0,
+                                                            };
+                                                            items.push((id, consumer, idle_time, Vec::new()));
+                                                        }
+                                                    }
+                                                }
+                                                Ok(items)
+                                            },
+                                            Ok(bb8_redis::redis::Value::Int(0)) | Ok(bb8_redis::redis::Value::Nil) => Ok(Vec::new()),
+                                            Ok(_) => Ok(Vec::new()),
+                                            Err(e) => Err(Error::RedisError(e)),
+                                        };
 
                                     match more_pending {
                                         Ok(more_msgs) if !more_msgs.is_empty() => {
@@ -734,11 +765,10 @@ impl Consumer {
                 type DeliveryTime = u64;
                 type AdditionalInfo = Vec<(String, u64)>;
                 type PendingItem = (String, ConsumerName, DeliveryTime, AdditionalInfo);
-                type PendingDetailsResult =
-                    std::result::Result<Vec<PendingItem>, bb8_redis::redis::RedisError>;
-
-                // Use a simpler, direct approach that works with Redis
-                let pending_details: PendingDetailsResult = bb8_redis::redis::cmd("XPENDING")
+                
+                // First try to get the raw response to handle different formats
+                let pending_raw: std::result::Result<bb8_redis::redis::Value, bb8_redis::redis::RedisError> = 
+                    bb8_redis::redis::cmd("XPENDING")
                         .arg(stream_key)
                         .arg(group_name)
                         .arg("-")  // start ID
@@ -746,6 +776,54 @@ impl Consumer {
                         .arg(BATCH_SIZE)  // batch size
                         .query_async(&mut *conn)
                         .await;
+
+                // Convert the raw response to our expected format, handling edge cases
+                let pending_details: std::result::Result<Vec<PendingItem>, bb8_redis::redis::RedisError> = 
+                    match pending_raw {
+                        Ok(bb8_redis::redis::Value::Array(arr)) => {
+                            // Parse the array into our expected format
+                            let mut items = Vec::new();
+                            for val in arr {
+                                if let bb8_redis::redis::Value::Array(entry) = val {
+                                    if entry.len() >= 4 {
+                                        // Extract values with proper error handling
+                                        let id = match &entry[0] {
+                                            bb8_redis::redis::Value::BulkString(s) => String::from_utf8_lossy(s).to_string(),
+                                            _ => continue,
+                                        };
+                                        let consumer = match &entry[1] {
+                                            bb8_redis::redis::Value::BulkString(s) => String::from_utf8_lossy(s).to_string(),
+                                            _ => continue,
+                                        };
+                                        let idle_time = match &entry[2] {
+                                            bb8_redis::redis::Value::Int(i) => *i as u64,
+                                            bb8_redis::redis::Value::BulkString(s) => {
+                                                String::from_utf8_lossy(s).parse::<u64>().unwrap_or(0)
+                                            },
+                                            _ => 0,
+                                        };
+                                        // Additional info is optional
+                                        let additional_info = Vec::new();
+                                        items.push((id, consumer, idle_time, additional_info));
+                                    }
+                                }
+                            }
+                            Ok(items)
+                        },
+                        Ok(bb8_redis::redis::Value::Int(0)) => {
+                            // No pending messages
+                            Ok(Vec::new())
+                        },
+                        Ok(bb8_redis::redis::Value::Nil) => {
+                            // Stream or group doesn't exist
+                            Ok(Vec::new())
+                        },
+                        Ok(other) => {
+                            error!("[{}] Unexpected XPENDING response type: {:?}", stream_key, other);
+                            Ok(Vec::new())
+                        },
+                        Err(e) => Err(e),
+                    };
 
                 match pending_details {
                     Ok(pending_msgs) => {
@@ -837,8 +915,9 @@ impl Consumer {
                         }
                     },
                     Err(e) => {
-                        error!("[{}] Error getting pending message details: {}", stream_key, e);
-                        break;
+                        error!("[{}] Error getting pending message details: {} - Response type not vector compatible", stream_key, e);
+                        // Continue processing instead of breaking to handle transient errors
+                        processed = pending_count; // Exit the loop
                     },
                 }
             }


### PR DESCRIPTION
## Summary
- Fix "Response type not vector compatible" errors when processing pending messages
- Prevent backfill jobs from being lost when they timeout
- Improve Redis compatibility across different versions

## Changes

### Redis Type Error Fixes
- Handle different XPENDING response types (array, integer, nil) gracefully
- Add compatibility for Redis versions with and without IDLE parameter support
- Prevent crashes when streams/groups don't exist or have no pending messages

### Backfill Job Loss Prevention
- Remove SET EX Redis expiration that was causing jobs to disappear after 300 seconds
- Add `started_at` field to track actual job processing start time
- Fix `cleanup_expired_jobs` to correctly calculate timeouts from `started_at`
- Ensure expired jobs are returned to queue instead of being lost
- Fix double-incrementing of job attempts in retry logic

## Problem
The system was experiencing two critical issues:
1. Redis XPENDING commands returning unexpected response types causing "Response type not vector compatible" errors
2. ~22,000 backfill jobs were lost when they expired after 300 seconds without being returned to the queue

## Solution
- Robust parsing of Redis responses to handle all edge cases
- Jobs now remain in the in-progress queue without separate expiring keys
- Expired jobs are properly recovered and returned to the pending queue for retry

## Test plan
- [x] Verified code compiles with `make build`
- [x] Ran `cargo clippy` - no warnings
- [ ] Test with various Redis versions to ensure compatibility
- [ ] Monitor backfill job processing to ensure no job loss
- [ ] Verify expired jobs are properly returned to queue after 300 seconds

🤖 Generated with [Claude Code](https://claude.ai/code)