### PR TITLE
feat: Add support for custom headers in gRPC connections

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -16,6 +16,11 @@ WAYPOINT_REDIS__POOL_SIZE=100  # Increased from 5 to prevent connection exhausti
 
 # Farcaster Hub Configuration
 WAYPOINT_HUB__URL=snapchain.farcaster.xyz:3383
+# Custom headers for authentication and other purposes
+# Headers with underscores will be converted to hyphens (e.g., x_api_key becomes x-api-key)
+# WAYPOINT_HUB__HEADERS__x_api_key=your_api_key_here
+# WAYPOINT_HUB__HEADERS__authorization=Bearer your_token_here
+# WAYPOINT_HUB__HEADERS__x_custom_header=custom_value
 WAYPOINT_HUB__RETRY_MAX_ATTEMPTS=5
 WAYPOINT_HUB__RETRY_BASE_DELAY_MS=100
 WAYPOINT_HUB__RETRY_MAX_DELAY_MS=30000

--- a/README.md
+++ b/README.md
@@ -100,6 +100,10 @@ WAYPOINT_REDIS__URL=redis://localhost:6379
 
 # Farcaster Hub configuration
 WAYPOINT_HUB__URL=snapchain.farcaster.xyz:3383
+# Optional: Custom headers for authenticated hubs
+# Headers with underscores will be converted to hyphens (e.g., x_api_key becomes x-api-key)
+# WAYPOINT_HUB__HEADERS__x_api_key=your_api_key_here
+# WAYPOINT_HUB__HEADERS__authorization=Bearer your_token_here
 
 # MCP service configuration
 WAYPOINT_MCP__ENABLED=true

--- a/docker-compose.backfill.yml
+++ b/docker-compose.backfill.yml
@@ -55,6 +55,8 @@ services:
 
       # Farcaster Hub
       WAYPOINT_HUB__URL: ${WAYPOINT_HUB__URL:-snapchain.farcaster.xyz:3383}
+      # Custom headers for authentication (underscores in env vars will be converted to hyphens)
+      WAYPOINT_HUB__HEADERS__x_api_key: ${WAYPOINT_HUB__HEADERS__x_api_key}
       WAYPOINT_HUB__RETRY_MAX_ATTEMPTS: ${WAYPOINT_HUB__RETRY_MAX_ATTEMPTS:-5}
       WAYPOINT_HUB__RETRY_BASE_DELAY_MS: ${WAYPOINT_HUB__RETRY_BASE_DELAY_MS:-100}
       WAYPOINT_HUB__RETRY_MAX_DELAY_MS: ${WAYPOINT_HUB__RETRY_MAX_DELAY_MS:-30000}
@@ -93,6 +95,8 @@ services:
 
       # Farcaster Hub
       WAYPOINT_HUB__URL: ${WAYPOINT_HUB__URL:-snapchain.farcaster.xyz:3383}
+      # Custom headers for authentication (underscores in env vars will be converted to hyphens)
+      WAYPOINT_HUB__HEADERS__x_api_key: ${WAYPOINT_HUB__HEADERS__x_api_key}
       WAYPOINT_HUB__RETRY_MAX_ATTEMPTS: ${WAYPOINT_HUB__RETRY_MAX_ATTEMPTS:-5}
       WAYPOINT_HUB__RETRY_BASE_DELAY_MS: ${WAYPOINT_HUB__RETRY_BASE_DELAY_MS:-100}
       WAYPOINT_HUB__RETRY_MAX_DELAY_MS: ${WAYPOINT_HUB__RETRY_MAX_DELAY_MS:-30000}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -63,6 +63,8 @@ services:
 
       # Farcaster Hub
       WAYPOINT_HUB__URL: ${WAYPOINT_HUB__URL:-snapchain.farcaster.xyz:3383}
+      # Custom headers for authentication (underscores in env vars will be converted to hyphens)
+      WAYPOINT_HUB__HEADERS__x_api_key: ${WAYPOINT_HUB__HEADERS__x_api_key}
       WAYPOINT_HUB__RETRY_MAX_ATTEMPTS: ${WAYPOINT_HUB__RETRY_MAX_ATTEMPTS:-5}
       WAYPOINT_HUB__RETRY_BASE_DELAY_MS: ${WAYPOINT_HUB__RETRY_BASE_DELAY_MS:-100}
       WAYPOINT_HUB__RETRY_MAX_DELAY_MS: ${WAYPOINT_HUB__RETRY_MAX_DELAY_MS:-30000}
@@ -121,6 +123,8 @@ services:
 
       # Farcaster Hub
       WAYPOINT_HUB__URL: ${WAYPOINT_HUB__URL:-snapchain.farcaster.xyz:3383}
+      # Custom headers for authentication (underscores in env vars will be converted to hyphens)
+      WAYPOINT_HUB__HEADERS__x_api_key: ${WAYPOINT_HUB__HEADERS__x_api_key}
       WAYPOINT_HUB__RETRY_MAX_ATTEMPTS: ${WAYPOINT_HUB__RETRY_MAX_ATTEMPTS:-5}
       WAYPOINT_HUB__RETRY_BASE_DELAY_MS: ${WAYPOINT_HUB__RETRY_BASE_DELAY_MS:-100}
       WAYPOINT_HUB__RETRY_MAX_DELAY_MS: ${WAYPOINT_HUB__RETRY_MAX_DELAY_MS:-30000}
@@ -163,6 +167,8 @@ services:
 
       # Farcaster Hub
       WAYPOINT_HUB__URL: ${WAYPOINT_HUB__URL:-snapchain.farcaster.xyz:3383}
+      # Custom headers for authentication (underscores in env vars will be converted to hyphens)
+      WAYPOINT_HUB__HEADERS__x_api_key: ${WAYPOINT_HUB__HEADERS__x_api_key}
       WAYPOINT_HUB__RETRY_MAX_ATTEMPTS: ${WAYPOINT_HUB__RETRY_MAX_ATTEMPTS:-5}
       WAYPOINT_HUB__RETRY_BASE_DELAY_MS: ${WAYPOINT_HUB__RETRY_BASE_DELAY_MS:-100}
       WAYPOINT_HUB__RETRY_MAX_DELAY_MS: ${WAYPOINT_HUB__RETRY_MAX_DELAY_MS:-30000}

--- a/src/bin/test_direct_conversation.rs
+++ b/src/bin/test_direct_conversation.rs
@@ -24,6 +24,7 @@ async fn main() {
     // Create a new Hub then connect to it
     let mut hub = Hub::new(Arc::new(waypoint::config::HubConfig {
         url: hub_address.to_string(),
+        headers: std::collections::HashMap::new(),
         max_concurrent_connections: 5,
         max_requests_per_second: 10,
         retry_max_attempts: 5,

--- a/src/config.rs
+++ b/src/config.rs
@@ -5,6 +5,7 @@ use figment::{
     providers::{Env, Format, Serialized, Toml},
 };
 use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
 use std::path::Path;
 use thiserror::Error;
 
@@ -94,6 +95,10 @@ fn default_metrics_collection_interval() -> u64 {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct HubConfig {
     pub url: String,
+
+    // Custom headers for authentication and other purposes
+    #[serde(default)]
+    pub headers: HashMap<String, String>,
 
     // Connection limits
     #[serde(default = "default_hub_max_concurrent_connections")]
@@ -309,6 +314,7 @@ impl Default for HubConfig {
     fn default() -> Self {
         Self {
             url: "snapchain.farcaster.xyz:3383".to_string(),
+            headers: HashMap::new(),
             max_concurrent_connections: default_hub_max_concurrent_connections(),
             max_requests_per_second: default_hub_max_requests_per_second(),
             retry_max_attempts: default_retry_attempts(),

--- a/src/hub/client.rs
+++ b/src/hub/client.rs
@@ -9,6 +9,7 @@ use crate::{
 };
 use rand::Rng;
 use std::{
+    collections::HashMap,
     sync::Arc,
     time::{Duration, SystemTime, UNIX_EPOCH},
 };
@@ -151,11 +152,17 @@ impl Hub {
         })
     }
 
+    /// Add custom headers to request
+    fn add_custom_headers<T>(&self, request: tonic::Request<T>) -> tonic::Request<T> {
+        crate::hub::add_custom_headers(request, &self.config.headers)
+    }
+
     /// Create an empty hub instance for testing or mock purposes
     pub fn empty() -> Self {
         // Create default config
         let config = Arc::new(HubConfig {
             url: "snapchain.farcaster.xyz:3383".to_string(),
+            headers: HashMap::new(),
             max_concurrent_connections: 5,
             max_requests_per_second: 10,
             retry_max_attempts: 5,
@@ -217,7 +224,7 @@ impl Hub {
 
         // Test connection with info request
         // Get hub info without middleware first time to avoid double retry
-        let info_request = tonic::Request::new(GetInfoRequest {});
+        let info_request = self.add_custom_headers(tonic::Request::new(GetInfoRequest {}));
         match self.client.as_mut().unwrap().get_info(info_request).await {
             Ok(response) => {
                 let hub_info = response.into_inner();
@@ -349,18 +356,19 @@ impl Hub {
         let max_attempts = self.config.retry_max_attempts;
 
         loop {
-            // Get a mutable reference to the client
-            let client = self.client.as_mut().ok_or(Error::NotConnected)?;
-
             // Create the request
             let request = tonic::Request::new(BlocksRequest {
                 shard_id,
                 start_block_number: start_block,
                 stop_block_number: end_block,
             });
+            let request_with_headers = self.add_custom_headers(request);
+
+            // Get a mutable reference to the client
+            let client = self.client.as_mut().ok_or(Error::NotConnected)?;
 
             // Try to execute the request
-            match client.get_blocks(request).await {
+            match client.get_blocks(request_with_headers).await {
                 Ok(response) => {
                     // Reset error count and update success timestamp
                     self.error_count.store(0, std::sync::atomic::Ordering::SeqCst);
@@ -423,10 +431,12 @@ impl Hub {
 
         // Clone what we need for the closure to avoid borrowing self
         let client_clone = self.client.clone();
+        let headers = self.config.headers.clone();
 
         // Use retry_with_backoff
         self.retry_with_backoff(|| {
             let client_clone = client_clone.clone();
+            let headers = headers.clone();
             Box::pin(async move {
                 let mut client = client_clone.ok_or(Error::NotConnected)?;
                 let request = tonic::Request::new(ShardChunksRequest {
@@ -434,7 +444,8 @@ impl Hub {
                     start_block_number: start_block,
                     stop_block_number: end_block,
                 });
-                match client.get_shard_chunks(request).await {
+                let request_with_headers = crate::hub::add_custom_headers(request, &headers);
+                match client.get_shard_chunks(request_with_headers).await {
                     Ok(response) => Ok(response.into_inner()),
                     Err(status) => Err(Error::StatusError(status)),
                 }
@@ -457,14 +468,17 @@ impl Hub {
 
         // Clone what we need for the closure to avoid borrowing self
         let client_clone = self.client.clone();
+        let headers = self.config.headers.clone();
 
         // Use retry_with_backoff
         self.retry_with_backoff(|| {
             let client_clone = client_clone.clone();
+            let headers = headers.clone();
             Box::pin(async move {
                 let mut client = client_clone.ok_or(Error::NotConnected)?;
                 let request = tonic::Request::new(GetInfoRequest {});
-                match client.get_info(request).await {
+                let request_with_headers = crate::hub::add_custom_headers(request, &headers);
+                match client.get_info(request_with_headers).await {
                     Ok(response) => Ok(response.into_inner()),
                     Err(status) => Err(Error::StatusError(status)),
                 }
@@ -497,11 +511,13 @@ impl Hub {
 
         // Clone what we need for the closure to avoid borrowing self
         let client_clone = self.client.clone();
+        let headers = self.config.headers.clone();
 
         // Use retry_with_backoff
         self.retry_with_backoff(|| {
             let client_clone = client_clone.clone();
             let page_token_clone = page_token.clone();
+            let headers = headers.clone();
             Box::pin(async move {
                 let mut client = client_clone.ok_or(Error::NotConnected)?;
                 let request = tonic::Request::new(FidsRequest {
@@ -510,7 +526,8 @@ impl Hub {
                     reverse,
                     shard_id: 0,
                 });
-                match client.get_fids(request).await {
+                let request_with_headers = crate::hub::add_custom_headers(request, &headers);
+                match client.get_fids(request_with_headers).await {
                     Ok(response) => Ok(response.into_inner()),
                     Err(status) => Err(Error::StatusError(status)),
                 }

--- a/src/hub/mod.rs
+++ b/src/hub/mod.rs
@@ -9,3 +9,23 @@ pub mod subscriber;
 
 // Re-export data providers
 pub use providers::FarcasterHubClient;
+
+use std::collections::HashMap;
+use tonic::metadata::MetadataValue;
+
+/// Add custom headers to a gRPC request
+/// Converts underscores to hyphens in header names for common conventions
+pub fn add_custom_headers<T>(mut request: tonic::Request<T>, headers: &HashMap<String, String>) -> tonic::Request<T> {
+    for (key, value) in headers {
+        // Convert underscores to hyphens for header names
+        // This allows env vars like WAYPOINT_HUB__HEADERS__x_api_key to become x-api-key
+        let header_name = key.replace('_', "-");
+        
+        if let Ok(metadata_value) = MetadataValue::try_from(value) {
+            if let Ok(header_key) = tonic::metadata::MetadataKey::from_bytes(header_name.as_bytes()) {
+                request.metadata_mut().insert(header_key, metadata_value);
+            }
+        }
+    }
+    request
+}

--- a/src/services/streaming.rs
+++ b/src/services/streaming.rs
@@ -1482,6 +1482,8 @@ impl Service for StreamingService {
                 options.spam_filter_enabled = Some(true);
             }
 
+            options.hub_config = Some(Arc::new(context.config.hub.clone()));
+
             HubSubscriber::new(
                 client.clone(),
                 Arc::clone(&context.state.redis),


### PR DESCRIPTION
## Description

This PR introduces a flexible custom headers system for gRPC connections to Farcaster hubs. This change allows different hub providers to use their own header naming conventions and authentication schemes. 

This change will enable Waypoint operators to specify the required headers in the config. For example, if an operator is using Neynar's Snapchain node they can use `WAYPOINT_HUB__HEADERS__x_api_key=<API_KEY>` in the config.

Fixes #40 


## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring (no functional changes)

## Checklist

- [x] I have read the [CONTRIBUTING](../docs/contributing.md) document
- [x] My code follows the code style of this project
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have updated the documentation accordingly
- [x] I have verified that my changes do not introduce regressions

## Additional context

See #40 